### PR TITLE
Cgmckeever/http

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,16 @@ server->on("/settings.html", HTTPMethod::HTTP_GET, [server](){
 });
 ```
 
-> Stream a file to the server when using custom routing endpoints. See `example/save_config_demo.ino`
+> Stream a file to the server when using custom routing endpoints.
+> See `example/save_config_demo/save_config_demo.ino`
+
+### stopWebserver()
+```
+void ConfigManager::stopWebserver()
+```
+> Stops the built-in webserver to allow your custom project
+> webserver to run without port/resource interference.
+> See `example/custom-http/custom-http.ino`
 
 
 # Endpoints

--- a/examples/custom-http/custom-http.ino
+++ b/examples/custom-http/custom-http.ino
@@ -1,0 +1,201 @@
+const char *settingsHTML = (char *)"/settings.html";
+const char *stylesCSS = (char *)"/styles.css";
+const char *mainJS = (char *)"/main.js";
+
+const int DEVICENAMELEN = 28;
+
+struct Config {
+    char deviceName[DEVICENAMELEN];
+    int randomNumber;
+    int someNumber;
+    bool debugEnabled;
+} config;
+
+struct Metadata {
+    int8_t version;
+} meta;
+
+#include "ConfigManager.h"
+ConfigManager configManager;
+
+/**********
+***********
+
+Lets serve something with a different Library!!!
+This library is only for ESP32
+This library has naming conflicts with <Webserver.h>
+
+***********
+**********/
+
+#if defined(ARDUINO_ARCH_ESP32)
+namespace HTTP {
+  #include "esp_http_server.h"
+}
+HTTP::httpd_handle_t h_server = NULL;
+#endif
+
+void customHTTP(int port=80);
+
+void setup() {
+    Serial.begin(115200);
+    DEBUG_MODE = true;
+    DebugPrintln(F(""));
+
+    meta.version = 3;
+
+
+    // Settings
+    configManager.addParameter("deviceName", config.deviceName, DEVICENAMELEN);
+    configManager.addParameter("randomNumber", &config.randomNumber, get);
+    configManager.addParameter("someNumber", &config.someNumber);
+    configManager.addParameter("debugEnabled", &config.debugEnabled);
+
+    // Meta Settings
+    configManager.addParameter("version", &meta.version, get);
+
+    configManager.setAPICallback(APICallback);
+    configManager.setAPCallback(APCallback);
+
+    configManager.begin(config);
+
+    /**********
+    ***********
+
+    Allow for the stop of ConfigMangers built in
+    HTTP server, and start your own.
+
+    This example allows HTTP in AP mode, but provides
+    a custom HTTP server when in wifi station mode.
+
+    ***********
+    **********/
+
+    bool stopHTTP = true;
+    if (configManager.getMode() == station && stopHTTP) {
+        configManager.stopWebserver();
+        customHTTP();
+    }
+
+    /**********
+
+    Updating settings variables .. and now you know
+
+    **********/
+    config.someNumber = 62;
+    configManager.save();
+}
+
+void loop() {
+    configManager.loop();
+    DEBUG_MODE = config.debugEnabled;
+
+    // Add your loop code here
+    config.randomNumber = (int) random(1000);
+    configManager.save();
+}
+
+
+void APCallback(WebServer *server) {
+    server->on("/styles.css", HTTPMethod::HTTP_GET, [server](){
+        configManager.streamFile(stylesCSS, mimeCSS);
+    });
+
+    DebugPrintln(F("AP Mode Enabled. You can call other functions that should run after a mode is enabled ... "));
+}
+
+
+void APICallback(WebServer *server) {
+  server->on("/disconnect", HTTPMethod::HTTP_GET, [server](){
+    configManager.clearWifiSettings(false);
+  });
+
+  server->on("/config", HTTPMethod::HTTP_GET, [server](){
+    configManager.streamFile(settingsHTML, mimeHTML);
+  });
+
+  // NOTE: css/js can be embedded in a single page HTML
+  server->on("/styles.css", HTTPMethod::HTTP_GET, [server](){
+    configManager.streamFile(stylesCSS, mimeCSS);
+  });
+
+  server->on("/main.js", HTTPMethod::HTTP_GET, [server](){
+    configManager.streamFile(mainJS, mimeJS);
+  });
+
+  server->on("/reboot", HTTPMethod::HTTP_GET, [server](){
+    ESP.restart();
+  });
+
+}
+
+#if defined(ARDUINO_ARCH_ESP32)
+static esp_err_t indexHandler(HTTP::httpd_req_t *req) {
+    Serial.println("/");
+    String resp = "Stored Config randomNumber: " + (String) config.randomNumber;
+    return HTTP::httpd_resp_send(req, resp.c_str(), strlen(resp.c_str()));
+}
+void registerIndex() {
+    HTTP::httpd_uri_t uri = {
+    .uri       = "serving /",
+    .method    = HTTP::HTTP_GET,
+    .handler   = indexHandler,
+    .user_ctx  = NULL
+  };
+
+  HTTP::httpd_register_uri_handler(h_server, &uri);
+}
+
+static esp_err_t rebootHandler(HTTP::httpd_req_t *req) {
+    Serial.println("serving /reboot");
+    const char resp[] = "Rebooting";
+    HTTP::httpd_resp_send(req, resp, strlen(resp));
+    ESP.restart();
+    return ESP_OK;
+}
+void registerReboot() {
+    HTTP::httpd_uri_t uri = {
+    .uri       = "/reboot",
+    .method    = HTTP::HTTP_GET,
+    .handler   = rebootHandler,
+    .user_ctx  = NULL
+  };
+
+  HTTP::httpd_register_uri_handler(h_server, &uri);
+}
+
+static esp_err_t scanHandler(HTTP::httpd_req_t *req) {
+    Serial.println("serving /scanner");
+    String resp = configManager.scanNetworks();
+    return HTTP::httpd_resp_send(req, resp.c_str(), strlen(resp.c_str()));
+}
+void registerScan() {
+    HTTP::httpd_uri_t uri = {
+    .uri       = "/scanner",
+    .method    = HTTP::HTTP_GET,
+    .handler   = scanHandler,
+    .user_ctx  = NULL
+  };
+
+  HTTP::httpd_register_uri_handler(h_server, &uri);
+}
+
+void customHTTP(int port) {
+    Serial.println("Setting up custom HTTP");
+    HTTP::httpd_config_t h_config = HTTPD_DEFAULT_CONFIG();
+    h_config.server_port = port;
+    HTTP::httpd_start(&h_server, &h_config);
+
+    registerIndex();
+    registerScan();
+    registerReboot();
+
+    Serial.print("Ready at: http://");
+    Serial.println(WiFi.localIP());
+}
+#else
+void customHTTP(int port) {
+    Serial.println("No HTTP Server defined for ESP8266");
+}
+#endif
+

--- a/examples/custom-http/data/index.html
+++ b/examples/custom-http/data/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <link rel="stylesheet" href="styles.css">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>ConfigManager</title>
+    </head>
+    <body>
+        <div class="container">
+            <h1 style="text-align: center;">Wifi Details</h1>
+            <form method="post" action="/">
+                <div class="field-group">
+                    <label>SSID</label>
+                    <input name="ssid" type="text" size="32">
+                </div>
+                <div class="field-group">
+                    <label>Password</label>
+                    <input name="password" type="text" size="64">
+                </div>
+                <div class="button-container">
+                    <button type="submit">Save</button>
+                </div>
+            </form>
+        </div>
+    </body>
+</html>

--- a/examples/custom-http/data/main.js
+++ b/examples/custom-http/data/main.js
@@ -1,0 +1,89 @@
+$( document ).ready(function() {
+
+  var validationSettings = {
+    rules: {
+      device_name: {
+        required: true
+      },
+      inching_delay: {
+        required: true
+      },
+      led: {
+        required: true
+      }
+    }
+  };
+
+  $.ajax({
+         url: '/settings',
+         success: function(data) {
+           $.each(data, function(key, value, data) {
+             var input = document.getElementsByName(key);
+             if (input.length > 0) {
+               var dataType = input[0].getAttribute("data-type");
+               if (dataType == "boolean") {
+                 $(input[0]).prop("checked", value);
+                 return
+               }
+
+               $(input[0]).val(value);
+             }
+           });
+         }
+  });
+
+  $.fn.serializeObject = function() {
+    var o = {};
+    
+    var a = this.serializeArray();
+    $.each(a, function() {
+      var input = document.getElementsByName(this.name);
+      var value = this.value;
+      var dataType = input[0].getAttribute("data-type");
+      if (dataType == "number") value = parseFloat(value);
+      if (dataType == "boolean") value = value == "on";
+
+      if (o[this.name]) {
+        if (!o[this.name].push) {
+          o[this.name] = [o[this.name]];
+        }
+        o[this.name].push(value || '');
+      } else {
+        o[this.name] = value || '';
+      }
+    });
+
+    var c = $('input[type=radio],input[type=checkbox]',this);
+    $.each(c, function(){
+      if(!o.hasOwnProperty(this.name)){
+        o[this.name] = false;
+      }
+    });
+
+    return o;
+  };
+
+  $('form').validate(validationSettings);
+  $('form').on('submit', function(e) {
+    document.getElementById("status").innerHTML = "";
+    if($(this).valid()) {
+      e.preventDefault();
+
+      var formData = $(this).serializeObject();
+
+      // Send data as a PUT request
+      $.ajax({
+             url: '/settings',
+             type: 'PUT',
+             data: JSON.stringify(formData),
+             contentType: 'application/json',
+             success: function(data) {
+               console.log(formData);
+               document.getElementById("status").innerHTML = "Settings Updated"
+             }
+      });
+
+      return false;
+    }
+  });
+});

--- a/examples/custom-http/data/settings.html
+++ b/examples/custom-http/data/settings.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.16.0/jquery.validate.min.js"></script>
+    <script src="main.js"></script>
+    <title>ConfigManager</title>
+  </head>
+  <body>
+    <div class="container">
+      <h1 style="text-align: center;">Settings</h1>
+      <form method="post" action="/settings">
+        <div class="field-group">
+          <label>Device Name</label>
+          <input name="deviceName" type="text" size="32" data-type="text">
+        </div>
+        <div class="field-group">
+          <label>Some Number</label>
+          <input name="someNumber" type="text" size="32" data-type="number">
+        </div>
+        <div class="field-group">
+          <label>Debug Enabled</label>
+          <input name="debugEnabled" type="checkbox" data-type="boolean">
+        </div>
+        <div class="button-container">
+          <h2 style="" id="status"></h2>
+          <button type="submit">Save</button>
+        </div>
+      </form>
+    </div>
+  </body>
+</html>

--- a/examples/custom-http/data/styles.css
+++ b/examples/custom-http/data/styles.css
@@ -1,0 +1,90 @@
+body {
+    color: #434343;
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size: 14px;
+    line-height: 1.42857142857143;
+    padding: 20px;
+}
+.container {
+    margin: 0 auto;
+    max-width: 400px;
+}
+form .error {
+    color: #8A1F11 !important;
+    border-color: #8A1F11;
+}
+label.error {
+    text-transform: none
+}
+p.error {
+    margin-bottom: 10px
+}
+p.inline-errors, p.error {
+    background: none
+      border-color: none
+    border: none
+    clear: both
+    font-size: 12px
+}
+form .field-group {
+    box-sizing: border-box;
+    clear: both;
+    padding: 4px 0;
+    position: relative;
+    margin: 1px 0;
+    width: 100%;
+}
+form .field-group > label {
+    color: #757575;
+    display: block;
+    margin: 0 0 5px 0;
+    padding: 5px 0 0;
+    position: relative;
+    word-wrap: break-word;
+}
+input[type=text] {
+    background: #fff;
+    border: 1px solid #d0d0d0;
+    border-radius: 2px;
+    box-sizing: border-box;
+    color: #434343;
+    font-family: inherit;
+    font-size: inherit;
+    height: 2.14285714em;
+    line-height: 1.4285714285714;
+    padding: 4px 5px;
+    margin: 0;
+    width: 100%;
+}
+input[type=text]:focus {
+    border-color: #4C669F;
+    outline: 0;
+}
+.button-container {
+    box-sizing: border-box;
+    clear: both;
+    margin: 1px 0 0;
+    padding: 4px 0;
+    position: relative;
+    width: 100%;
+}
+button[type=submit] {
+    box-sizing: border-box;
+    background: #f5f5f5;
+    border: 1px solid #bdbdbd;
+    border-radius: 2px;
+    color: #434343;
+    cursor: pointer;
+    display: inline-block;
+    font-family: inherit;
+    font-size: 14px;
+    font-variant: normal;
+    font-weight: 400;
+    height: 2.14285714em;
+    line-height: 1.42857143;
+    margin: 0;
+    padding: 4px 10px;
+    text-decoration: none;
+    vertical-align: baseline;
+    white-space: nowrap;
+}

--- a/examples/save_config_demo/save_config_demo.ino
+++ b/examples/save_config_demo/save_config_demo.ino
@@ -44,10 +44,15 @@ void APICallback(WebServer *server) {
     configManager.streamFile(mainJS, mimeJS);
   });
 
+  server->on("/reboot", HTTPMethod::HTTP_GET, [server](){
+    ESP.restart();
+  });
+
 }
 
 void setup() {
   Serial.begin(115200);
+  DEBUG_MODE = true;
   DebugPrintln(F(""));
 
   meta.version = 3;
@@ -56,7 +61,7 @@ void setup() {
   configManager.setAPName("Demo");
   configManager.setAPFilename("/index.html");
 
-  // Settings variables 
+  // Settings variables
   configManager.addParameter("device_name", config.device_name, 32);
   configManager.addParameter("inching_delay", &config.inching_delay);
   configManager.addParameter("led", &config.led);
@@ -74,4 +79,6 @@ void setup() {
 
 void loop() {
   configManager.loop();
+
+  // Add your loop code here
 }

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -20,21 +20,23 @@ void ConfigManager::setup() {
   char ssid[SSID_LENGTH];
   char password[PASSWORD_LENGTH];
 
-  DebugPrintln(F("Reading saved configuration"));
-
   DebugPrint(F("MAC: "));
   DebugPrintln(WiFi.macAddress());
 
+  DebugPrintln(F("Reading saved configuration"));
   EEPROM.get(0, magic);
-  EEPROM.get(MAGIC_LENGTH, ssid);
-  DebugPrint(F("SSID: \""));
-  DebugPrint(ssid);
-  DebugPrintln(F("\""));
-  EEPROM.get(MAGIC_LENGTH + SSID_LENGTH, password);
-  readConfig();
 
   if (memcmp(magic, magicBytes, MAGIC_LENGTH) == 0) {
+    EEPROM.get(MAGIC_LENGTH, ssid);
+    DebugPrint(F("SSID: \""));
+    DebugPrint(ssid);
+    DebugPrintln(F("\""));
+
+    EEPROM.get(MAGIC_LENGTH + SSID_LENGTH, password);
+    readConfig();
+
     WiFi.begin(ssid, password[0] == '\0' ? NULL : password);
+
     if (wifiConnected()) {
       DebugPrint(F("Connected to "));
       DebugPrint(ssid);
@@ -42,42 +44,46 @@ void ConfigManager::setup() {
       DebugPrintln(WiFi.localIP());
 
       WiFi.mode(WIFI_STA);
+
       startApi();
-      return;
     }
   } else {
     // We are at a cold start, don't bother timing out.
-    DebugPrint(F("MagicBytes mismatch - SSID: "));
-    DebugPrintln(ssid);
     apTimeout = 0;
+    DebugPrintln(F("MagicBytes mismatch"));
   }
 
-  startAP();
+  if (this->getMode() != station) {
+    startAP();
+    startAPApi();
+  }
 }
 
 void ConfigManager::loop() {
-  if (mode == ap && apTimeout > 0 &&
-      ((millis() - apStart) / 1000) > (uint16_t)apTimeout) {
-    ESP.restart();
+
+  if (this->getMode() == ap) {
+    if (apTimeout > 0 &&
+        ((millis() - apStart) / 1000) > (uint16_t)apTimeout) {
+      ESP.restart();
+    }
+
+    if (dnsServer) {
+      dnsServer->processNextRequest();
+    }
   }
 
-  if (dnsServer) {
-    dnsServer->processNextRequest();
-  }
-
-  if (server) {
+  if (server && this->webserverRunning) {
     server->handleClient();
   }
 }
 
-//
-// ConfigManager AP Utilities 
-//
-
-Mode ConfigManager::getMode() {
-  return this->mode;
+wifiModes ConfigManager::getMode() {
+  return this->wifiMode;
 }
 
+//
+// ConfigManager AP Utilities
+//
 void ConfigManager::setAPName(const char* name) {
   this->apName = (char*)name;
 }
@@ -95,7 +101,7 @@ void ConfigManager::setAPTimeout(const int timeout) {
 }
 
 void ConfigManager::startAP() {
-  mode = ap;
+  this->wifiMode = ap;
 
   DebugPrintln(F("Starting Access Point"));
 
@@ -119,31 +125,34 @@ void ConfigManager::startAP() {
   dnsServer->setErrorReplyCode(DNSReplyCode::NoError);
   dnsServer->start(DNS_PORT, "*", ip);
 
+  apStart = millis();
+}
+
+void ConfigManager::startAPApi() {
+  DebugPrintln(F("AP Api Mode"));
   createBaseWebServer();
 
   if (apCallback) {
     apCallback(server.get());
   }
 
-  server->begin();
-
-  apStart = millis();
+  this->startWebserver();
 }
 
 void ConfigManager::startApi() {
-  mode = api;
-
+  DebugPrintln(F("Station Mode"));
   createBaseWebServer();
+
   server->on("/settings", HTTPMethod::HTTP_GET,
-             std::bind(&ConfigManager::handleRESTGet, this));
+             std::bind(&ConfigManager::handleSettingsGetREST, this));
   server->on("/settings", HTTPMethod::HTTP_PUT,
-             std::bind(&ConfigManager::handleRESTPut, this));
+             std::bind(&ConfigManager::handleSettingsPutREST, this));
 
   if (apiCallback) {
     apiCallback(server.get());
   }
 
-  server->begin();
+  this->startWebserver();
 }
 
 void ConfigManager::setAPCallback(std::function<void(WebServer*)> callback) {
@@ -172,6 +181,7 @@ bool ConfigManager::wifiConnected() {
   while (i < wifiConnectRetries) {
     if (WiFi.status() == WL_CONNECTED) {
       DebugPrintln("");
+      this->wifiMode = station;
       return true;
     }
 
@@ -232,13 +242,48 @@ void ConfigManager::clearWifiSettings(bool reboot) {
   }
 }
 
+String ConfigManager::scanNetworks() {
+  DynamicJsonDocument doc(1024);
+  JsonArray jsonArray = doc.createNestedArray();
+
+  DebugPrintln("Scanning WiFi networks...");
+  int n = WiFi.scanNetworks();
+  DebugPrintln("scan complete");
+  if (n == 0) {
+    DebugPrintln("no networks found");
+  } else {
+    DebugPrint(n);
+    DebugPrintln(" networks found:");
+
+    for (int i = 0; i < n; ++i) {
+      String ssid = WiFi.SSID(i);
+      int rssi = WiFi.RSSI(i);
+      String security =
+          WiFi.encryptionType(i) == WIFI_OPEN ? "none" : "enabled";
+
+      DebugPrint("Name: ");
+      DebugPrint(ssid);
+      DebugPrint(" - Strength: ");
+      DebugPrint(rssi);
+      DebugPrint(" - Security: ");
+      DebugPrintln(security);
+
+      JsonObject obj = doc.createNestedObject();
+      obj["ssid"] = ssid;
+      obj["strength"] = rssi;
+      obj["security"] = security == "none" ? false : true;
+      jsonArray.add(obj);
+    }
+  }
+
+  String jsonSerialized;
+  serializeJson(jsonArray, jsonSerialized);
+  return jsonSerialized;
+}
+
 //
 // ConfigManager Config Utilities
 //
-void ConfigManager::save() {
-  this->writeConfig();
-}
-
 JsonObject ConfigManager::decodeJson(String jsonString) {
   DynamicJsonDocument doc(1024);
 
@@ -247,10 +292,9 @@ JsonObject ConfigManager::decodeJson(String jsonString) {
   }
 
   auto error = deserializeJson(doc, jsonString);
-
   if (error) {
-    Serial.print(F("deserializeJson() failed with code "));
-    Serial.println(error.c_str());
+    DebugPrint(F("deserializeJson() failed with code "));
+    DebugPrintln(error.c_str());
     return doc.as<JsonObject>();
   }
 
@@ -265,6 +309,22 @@ void ConfigManager::readConfig() {
   }
 }
 
+JsonObject ConfigManager::asJson() {
+  DynamicJsonDocument doc(1024);
+  JsonObject obj = doc.createNestedObject();
+
+  std::list<BaseParameter*>::iterator it;
+  for (it = parameters.begin(); it != parameters.end(); ++it) {
+    if ((*it)->getMode() == set) {
+      continue;
+    }
+
+    (*it)->toJson(&obj);
+  }
+
+  return obj;
+}
+
 void ConfigManager::writeConfig() {
   byte* ptr = (byte*)config;
 
@@ -272,6 +332,22 @@ void ConfigManager::writeConfig() {
     EEPROM.write(CONFIG_OFFSET + i, *(ptr++));
   }
   EEPROM.commit();
+}
+void ConfigManager::save() {
+  this->writeConfig();
+}
+
+void ConfigManager::updateFromJson(JsonObject obj) {
+  std::list<BaseParameter*>::iterator it;
+  for (it = parameters.begin(); it != parameters.end(); ++it) {
+    if ((*it)->getMode() == get) {
+      continue;
+    }
+
+    (*it)->fromJson(&obj);
+  }
+
+  writeConfig();
 }
 
 void ConfigManager::clearSettings(bool reboot) {
@@ -291,6 +367,17 @@ void ConfigManager::clearSettings(bool reboot) {
 //
 // ConfigManager HTTP Utilities
 //
+void ConfigManager::startWebserver() {
+  this->server->begin();
+  this->webserverRunning = true;
+}
+
+void ConfigManager::stopWebserver() {
+  this->server->stop();
+  DebugPrintln(F("Webserver Stopped"));
+  this->webserverRunning = false;
+}
+
 void ConfigManager::setWebPort(const int port) {
   this->webPort = port;
 }
@@ -309,8 +396,12 @@ void ConfigManager::createBaseWebServer() {
              std::bind(&ConfigManager::handleAPGet, this));
   server->on("/", HTTPMethod::HTTP_POST,
              std::bind(&ConfigManager::handleAPPost, this));
+  DebugPrintln("Index page registered");
+
   server->on("/scan", HTTPMethod::HTTP_GET,
              std::bind(&ConfigManager::handleScanGet, this));
+  DebugPrintln("Scan page registered");
+
   server->onNotFound(std::bind(&ConfigManager::handleNotFound, this));
 }
 
@@ -360,83 +451,29 @@ void ConfigManager::handleAPPost() {
 }
 
 void ConfigManager::handleScanGet() {
-  DynamicJsonDocument doc(1024);
-  JsonArray jsonArray = doc.createNestedArray();
-
-  DebugPrintln("Scanning WiFi networks...");
-  int n = WiFi.scanNetworks();
-  DebugPrintln("scan complete");
-  if (n == 0) {
-    DebugPrintln("no networks found");
-  } else {
-    DebugPrint(n);
-    DebugPrintln(" networks found:");
-
-    for (int i = 0; i < n; ++i) {
-      String ssid = WiFi.SSID(i);
-      int rssi = WiFi.RSSI(i);
-      String security =
-          WiFi.encryptionType(i) == WIFI_OPEN ? "none" : "enabled";
-
-      DebugPrint("Name: ");
-      DebugPrint(ssid);
-      DebugPrint(" - Strength: ");
-      DebugPrint(rssi);
-      DebugPrint(" - Security: ");
-      DebugPrintln(security);
-
-      JsonObject obj = doc.createNestedObject();
-      obj["ssid"] = ssid;
-      obj["strength"] = rssi;
-      obj["security"] = security == "none" ? false : true;
-      jsonArray.add(obj);
-    }
-  }
-
-  String body;
-  serializeJson(jsonArray, body);
-
+  String body = scanNetworks();
   server->send(200, FPSTR(mimeJSON), body);
 }
 
-void ConfigManager::handleRESTGet() {
-  DynamicJsonDocument doc(1024);
-  JsonObject obj = doc.createNestedObject();
-
-  std::list<BaseParameter*>::iterator it;
-  for (it = parameters.begin(); it != parameters.end(); ++it) {
-    if ((*it)->getMode() == set) {
-      continue;
-    }
-
-    (*it)->toJson(&obj);
-  }
-
+void ConfigManager::handleSettingsGetREST() {
+  JsonObject obj = asJson();
   String body;
   serializeJson(obj, body);
 
+  DebugPrintln(body);
   server->send(200, FPSTR(mimeJSON), body);
 }
 
-void ConfigManager::handleRESTPut() {
+void ConfigManager::handleSettingsPutREST() {
   DynamicJsonDocument doc(1024);
   auto error = deserializeJson(doc, server->arg("plain"));
   if (error) {
     server->send(400, FPSTR(mimeJSON), "");
     return;
   }
+
   JsonObject obj = doc.as<JsonObject>();
-
-  std::list<BaseParameter*>::iterator it;
-  for (it = parameters.begin(); it != parameters.end(); ++it) {
-    if ((*it)->getMode() == get) {
-      continue;
-    }
-
-    (*it)->fromJson(&obj);
-  }
-
-  writeConfig();
+  updateFromJson(obj);
 
   server->send(204, FPSTR(mimeJSON), "");
 }
@@ -451,8 +488,8 @@ void ConfigManager::handleNotFound() {
     DebugPrintln(header);
     server->sendHeader("Location", String("http://") + URI, true);
     server->send(302, FPSTR(mimePlain), "");
-    // Empty content inhibits Content-length header so we have to close the
-    // socket ourselves.
+    // Empty content inhibits Content-length header so we
+    // have to close the socket ourselves.
     server->client().stop();
     return;
   }
@@ -482,9 +519,9 @@ String ConfigManager::toStringIP(IPAddress ip) {
   return res;
 }
 
-#if defined(localbuild)
-// used to compile the project from the project and not as a library from
-// another one
+#ifdef localbuild
+// used to compile the project from the project
+// and not as a library from another one
 void setup() {}
 void loop() {}
 #endif


### PR DESCRIPTION
# Tested

Multi-configurations on both ESP8266 and ESP32

# Objective

To provide optional settings to disable ConfigManagers built-in Wifi and HTTP server. 

- [X] Not be too destructive of the core library

# Reason

I want to use another package that has a conflicting server, and didn't necessarily want to have the device running multiple all the time. 

# End Result

To additional methods provided that will one-time-only (ie no toggling out of it, as it is usually done during `setup`) disable either `Wifi` or `HTTP`, but allow either to also continue to work if they are not both turned off (ie, HTTP will still serve if WIFI has been disabled)

```
configManager.disableWIFI();
configManager.disableHTTP();
```

Of course, this is **Buyer Beware**, as you can't really have a useful HTTP thing without WIFI, so you would need to have custom [WIFI](https://github.com/cgmckeever/ConfigManager/blob/cgmckeever/http/examples/custom-http/custom-http.ino#L31) or [HTTP](https://github.com/cgmckeever/ConfigManager/blob/cgmckeever/http/examples/custom-http/custom-http.ino#L179) methods of your own.

## Abstracted out methods used by ConfigManagers HTTP

For the HTTP calls (ie `/scan`), I unrolled some the [underlying code](https://github.com/cgmckeever/ConfigManager/blob/cgmckeever/http/src/ConfigManager.cpp#L259) so they are more readily exposed to [other processes](https://github.com/cgmckeever/ConfigManager/blob/cgmckeever/http/examples/custom-http/custom-http.ino#L165)

## Example Code

[Example code provided](https://github.com/cgmckeever/ConfigManager/tree/cgmckeever/http/examples/custom-http) which should easily let one test the code out, as well as try the different disabling configurations.